### PR TITLE
fix "Abort trap: 6" during dbase_replace_record()

### DIFF
--- a/dbf_head.c
+++ b/dbf_head.c
@@ -190,7 +190,7 @@ int put_dbf_field(dbhead_t *dbh, dbfield_t *dbf)
 	/* build the on disk field info */
 	scp = dbf->db_fname; dcp = dbfield.dbf_name;
 
-	strlcpy(dbfield.dbf_name, dbf->db_fname, DBF_NAMELEN + 1);
+	strlcpy(dbfield.dbf_name, dbf->db_fname, DBF_NAMELEN);
 
 	dbfield.dbf_type = dbf->db_type;
 	switch (dbf->db_type) {


### PR DESCRIPTION
When using dbase package in Mac OS X this error is raised when a record is written to disk, for example using dbase_replace_record

Make output:
dbf_head.c:193:2: warning: '__builtin___strlcpy_chk' will always overflow destination buffer [-Wbuiltin-memcpy-chk-size]
        strlcpy(dbfield.dbf_name, dbf->db_fname, DBF_NAMELEN + 1);

Setting compiler flag -Wno-builtin-memcpy-chk-size does not fix this problem

See https://bugs.php.net/bug.php?id=74983

I'm use PHP 7.1.8 (cli) (built: Aug  7 2017 15:02:45) ( NTS )